### PR TITLE
Add /devices/<device_id>/apps/<app_id>/state for checking the applica…

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,12 @@ All routes return JSON.
 - `GET /devices/list` (list all registered devices and state)
 - `GET /devices/connect/<device_id>` (force connection attempt)
 - `GET /devices/state/<device_id>` (return state)
-- `GET /devices/<device_id>/apps/running` (return running user apps)
-- `GET /devices/<device_id>/apps/state/<app_id>` (returns if appid is running)
 - `GET /devices/action/<device_id>/<action_id>` (request action)
+- `GET /devices/<device_id>/apps/running` (return running user apps)
 - `GET /devices/<device_id>/apps/<app_id>/start` (start an app)
 - `GET /devices/<device_id>/apps/<app_id>/stop` (stop an app)
+- `GET /devices/<device_id>/apps/<app_id>/state` (check app state)
+- `GET /devices/<device_id>/apps/state/<app_id>` (check app state, deprecated format)
 - `POST /devices/add` (see below)
 
 #### Add A Device
@@ -86,6 +87,7 @@ POST JSON in the following format with the HTTP header `Content-Type: applicatio
 
 - `GET /devices/<device_id>/apps/running`
 - `/devices/<device_id>/apps/state/<app_id>`
+- `/devices/<device_id>/apps/<app_id>/state`
 
 app_id can be anything from a single word, e.g. 'netflix' or the full package name, e.g. com.netflix.ninja
 

--- a/firetv/__main__.py
+++ b/firetv/__main__.py
@@ -137,6 +137,10 @@ def get_app_state(device_id, app_id):
         abort(404)
     return jsonify(status=devices[device_id].app_state(app_id))
 
+@app.route('/devices/<device_id>/apps/<appid>/state', methods=['GET'])
+def get_app_state_alt(device_id, app_id):
+    return get_app_state(device_id, app_id)
+
 @app.route('/devices/action/<device_id>/<action_id>', methods=['GET'])
 def device_action(device_id, action_id):
     """ Initiate device action via HTTP GET. """


### PR DESCRIPTION
…tion state.

Adds /devices/<device_id>/apps/<app_id>/state to check for the application state.
This format follows the same form of other app-specific actions, simplifying implementatiuons.
The previous format is kept for backwards compatibility, but its use is discouraged.