### PR TITLE
Always report the application state, follow same naming in state dict as elsewhere

### DIFF
--- a/firetv/__init__.py
+++ b/firetv/__init__.py
@@ -93,7 +93,7 @@ class FireTV:
 
     def app_state(self, app):
         """ Informs if application is running """
-        if self.state != STATE_PLAYING:
+        if self.state == STATE_OFF or self.state == STATE_DISCONNECTED:
             return STATE_OFF
         if len(self._ps(app)) > 0:
             return STATE_ON

--- a/firetv/__main__.py
+++ b/firetv/__main__.py
@@ -135,7 +135,8 @@ def get_app_state(device_id, app_id):
         abort(403)
     if device_id not in devices:
         abort(404)
-    return jsonify(status=devices[device_id].app_state(app_id))
+    app_state = devices[device_id].app_state(app_id)
+    return jsonify(state=app_state, status=app_state)
 
 @app.route('/devices/<device_id>/apps/<app_id>/state', methods=['GET'])
 def get_app_state_alt(device_id, app_id):


### PR DESCRIPTION
First commit returns state like { "status": "on", "state": "on" } the former being backwards compatible to earlier reporting, state following the format of device listing.

Second commit makes skip status querying only when the device is off or disconnected.