### PR TITLE
adb 1.1.0 is not available on pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author='happyleaves',
     author_email='happyleaves.tfr@gmail.com',
     packages=['firetv'],
-    install_requires=['adb==1.1.0+git.master'],
+    install_requires=['adb>=1.1.0+git.master'],
     dependency_links=['https://github.com/google/python-adb/tarball/master#egg=adb-1.1.0+git.master'],
     extras_require={
         'firetv-server': ['Flask>=0.10.1', 'PyYAML>=3.12']


### PR DESCRIPTION
adb 1.1.0 is not available on pypi.
Updated install_requires to look for any version greater than 1.1.0.