### PR TITLE
RPI Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM python:2
-MAINTAINER Jon Bullen
+FROM hypriot/rpi-python
+MAINTAINER Dan Caws
 
 RUN apt-get update && apt-get install -y \
         libssl-dev \
         libusb-1.0-0 \
+	      gcc \
         python-dev \
         swig \
         curl \
@@ -15,12 +16,11 @@ RUN apt-get update && apt-get install -y \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip --no-cache-dir install --upgrade pip
-RUN pip --no-cache-dir install flask
-RUN pip --no-cache-dir install https://pypi.python.org/packages/source/M/M2Crypto/M2Crypto-0.24.0.tar.gz
+RUN pip install --upgrade pip
+RUN pip install flask
+RUN pip install https://pypi.python.org/packages/source/M/M2Crypto/M2Crypto-0.24.0.tar.gz
 RUN pip install /tmp/python-firetv-master[firetv-server]
 
 CMD ["firetv-server", "-c", "config/devices.yaml"]
 
-# docker build -t docker-firetv .
 # docker run -it --rm --name docker-firetv -p 5556:5556 docker-firetv


### PR DESCRIPTION
Updated docker file for RPI hardware, not sure if you want to break it out into another docker file. 

this one can be pulled with docker pull dancaws/rpi-firetvserver:latest