### PR TITLE
Change behaviour on connection failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
+.idea/
 firetv.egg-info

--- a/firetv/__init__.py
+++ b/firetv/__init__.py
@@ -107,8 +107,7 @@ class FireTV:
             self._adb = adb_commands.AdbCommands.ConnectDevice(
                 serial=self.host)
         except socket_error as serr:
-            if serr.errno != errno.ECONNREFUSED:
-                logging.warning("Couldn't connect to host: %s, error: %s", self.host, serr.strerror)
+            logging.warning("Couldn't connect to host: %s, error: %s", self.host, serr.strerror)
 
     @property
     def state(self):

--- a/firetv/__init__.py
+++ b/firetv/__init__.py
@@ -108,7 +108,7 @@ class FireTV:
                 serial=self.host)
         except socket_error as serr:
             if serr.errno != errno.ECONNREFUSED:
-                raise serr
+                logging.warning("Couldn't connect to host: %s, error: %s", self.host, serr.strerror)
 
     @property
     def state(self):

--- a/firetv/__main__.py
+++ b/firetv/__main__.py
@@ -21,6 +21,7 @@ Find device IP:
 import argparse
 import re
 import yaml
+import logging
 from flask import Flask, jsonify, request, abort
 from firetv import FireTV
 
@@ -54,7 +55,13 @@ def is_valid_device_id(device_id):
     :param device_id: Device identifier
     :returns: Valid or not.
     """
-    return valid_device_id.match(device_id)
+    valid = valid_device_id.match(device_id)
+    if not valid:
+        logging.error("A valid device identifier contains "
+                      "only ascii word characters or dashes. "
+                      "Device '%s' not added.",device_id)
+    return valid
+
 
 def is_valid_app_id(app_id):
     """ check if app identifier is valid.


### PR DESCRIPTION
I have multiple firetv devices, so it was not useful for me if one device could not be connected to the entire server would fail. Instead now the device is added as normal but with a status of "disconnected". The comments led me to believe this may have been the original intention.

Also some extra logging when failing to add devices.