### PR TITLE
Added Element FireTV input codes

### DIFF
--- a/firetv/__init__.py
+++ b/firetv/__init__.py
@@ -71,6 +71,18 @@ KEY_X = 52
 KEY_Y = 53
 KEY_Z = 54
 
+# Keyevent Codes for Element FireTV Edition inputs. These should theorhetically work for all FireTV...TVs.
+CYCLE_INPUT = 178
+COMPONENT1 = 249
+#COMPONENT2 = 250
+COMPOSITE1 = 247
+#COMPOSITE2 = 248
+HDMI1 = 243
+HDMI2 = 244
+HDMI3 = 245
+HDMI4 = 246
+#VGA = 251
+
 # Fire TV states.
 STATE_ON = 'on'
 STATE_IDLE = 'idle'


### PR DESCRIPTION
Added the Element FireTV input variables, to allow switching directly to an input.

These were found via the Android documentation and tested on my personal Element FireTV. I've commented out the lines which don't have corresponding inputs, but may in the future.

In addition, I would like to note that I am not a programmer, but I tinker and this seemed like an easy enough addition.