### PR TITLE
Bump version to 1.0.6 and fix requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # python-firetv
 
-`firetv` is a Python 2.x package that provides state information and some control of an Amazon Fire TV device over a network. This is achieved via ADB, so therefore requires [ADB Debugging](https://developer.amazon.com/public/solutions/devices/fire-tv/docs/connecting-adb-over-network) to be turned on. It includes `firetv-server`, an HTTP server to facilitate RESTful access to configured devices.
+`firetv` is a Python 2 and 3 package that provides state information and some control of an Amazon Fire TV device over a network. This is achieved via ADB, so therefore requires [ADB Debugging](https://developer.amazon.com/public/solutions/devices/fire-tv/docs/connecting-adb-over-network) to be turned on. It includes `firetv-server`, an HTTP server to facilitate RESTful access to configured devices.
 
 ## Installation
 
@@ -10,7 +10,7 @@ with `apt-get`: `swig libssl-dev python-dev libusb-1.0-0`
 
 with `yum`: `swig openssl-devel python-devel libusbx-devel`
 
-Be sure you install into a Python 2.x environment.
+Install the package using the command:
 
 `pip install firetv`
 
@@ -128,9 +128,6 @@ You can start or stop an app with the following commands:
 - `GET /devices/<device_id>/apps/<app_id>/stop` 
 
 app_id must be a package name, e.g. org.xbmc.kodi or com.netflix.ninja
-
-## Python 3
-`firetv` depends on [python-adb](https://github.com/google/python-adb), a pure-python implementation of the ADB protocol. It and its dependency [M2Crypto](https://github.com/martinpaljak/M2Crypto) are written for Python 2. Until they support Python 3, or an alternative is available, `firetv` will not support Python 3. The HTTP server is provided as a way for Python 3 (or other) software to utilize the features of `firetv`.
 
 ## Contribution
 

--- a/firetv/__init__.py
+++ b/firetv/__init__.py
@@ -25,6 +25,7 @@ HOME = 3
 VOLUME_UP = 24
 VOLUME_DOWN = 25
 POWER = 26
+SLEEP = 223
 PLAY_PAUSE = 85
 NEXT = 87
 PREVIOUS = 88
@@ -165,7 +166,7 @@ class FireTV:
     def turn_off(self):
         """ Send power action if device is not off. """
         if self._adb and self._screen_on:
-            self._power()
+            self._key(SLEEP)
 
     def home(self):
         """ Send home action. """

--- a/firetv/__init__.py
+++ b/firetv/__init__.py
@@ -82,7 +82,7 @@ STATE_OFF = 'off'
 STATE_PLAYING = 'play'
 STATE_PAUSED = 'pause'
 STATE_STANDBY = 'standby'
-STATE_DISCONNECTED = 'disconnected'
+STATE_UNKNOWN = 'unknown'
 
 PACKAGE_LAUNCHER = "com.amazon.tv.launcher"
 PACKAGE_SETTINGS = "com.amazon.tv.settings"
@@ -108,7 +108,7 @@ class FireTV:
         """ Connect to an Amazon Fire TV device.
 
         Will attempt to establish ADB connection to the given host.
-        Failure sets state to DISCONNECTED and disables sending actions.
+        Failure sets state to UNKNOWN and disables sending actions.
         """
         try:
             if self.adbkey:
@@ -129,7 +129,7 @@ class FireTV:
         """
         # Check if device is disconnected.
         if not self._adb:
-            return STATE_DISCONNECTED
+            return STATE_UNKNOWN
         # Check if device is off.
         if not self._screen_on:
             return STATE_OFF
@@ -151,7 +151,7 @@ class FireTV:
 
     def app_state(self, app):
         """ Informs if application is running """
-        if self.state == STATE_OFF or self.state == STATE_DISCONNECTED:
+        if not self._adb or not self._screen_on:
             return STATE_OFF
         if self.current_app["package"] == app:
             return STATE_ON
@@ -159,12 +159,12 @@ class FireTV:
 
     def turn_on(self):
         """ Send power action if device is off. """
-        if self.state == STATE_OFF:
+        if self._adb and not self._screen_on:
             self._power()
 
     def turn_off(self):
         """ Send power action if device is not off. """
-        if self.state != STATE_OFF:
+        if self._adb and self._screen_on:
             self._power()
 
     def home(self):
@@ -226,151 +226,151 @@ class FireTV:
     def media_previous(self):
         """ Send media previous action (results in rewind). """
         self._key(PREVIOUS)
-		
+
     def space(self):
         """ Send space keypress. """
         self._key(SPACE)
-		
+
     def key_0(self):
         """ Send 0 keypress. """
         self._key(KEY_0)
-		
+
     def key_1(self):
         """ Send 1 keypress. """
         self._key(KEY_1)
-		
+
     def key_2(self):
         """ Send 2 keypress. """
         self._key(KEY_2)
-		
+
     def key_3(self):
         """ Send 3 keypress. """
         self._key(KEY_3)
-		
+
     def key_4(self):
         """ Send 4 keypress. """
         self._key(KEY_4)
-		
+
     def key_5(self):
         """ Send 5 keypress. """
         self._key(KEY_5)
-		
+
     def key_6(self):
         """ Send 6 keypress. """
         self._key(KEY_6)
-		
+
     def key_7(self):
         """ Send 7 keypress. """
         self._key(KEY_7)
-		
+
     def key_8(self):
         """ Send 8 keypress. """
         self._key(KEY_8)
-		
+
     def key_9(self):
         """ Send 9 keypress. """
         self._key(KEY_9)
-		
+
     def key_a(self):
         """ Send a keypress. """
         self._key(KEY_A)
-		
+
     def key_b(self):
         """ Send b keypress. """
         self._key(KEY_B)
-		
+
     def key_c(self):
         """ Send c keypress. """
         self._key(KEY_C)
-		
+
     def key_d(self):
         """ Send d keypress. """
         self._key(KEY_D)
-		
+
     def key_e(self):
         """ Send e keypress. """
         self._key(KEY_E)
-		
+
     def key_f(self):
         """ Send f keypress. """
         self._key(KEY_F)
-		
+
     def key_g(self):
         """ Send g keypress. """
         self._key(KEY_G)
-		
+
     def key_h(self):
         """ Send h keypress. """
         self._key(KEY_H)
-		
+
     def key_i(self):
         """ Send i keypress. """
-        self._key(KEY_I)	
-	
+        self._key(KEY_I)
+
     def key_j(self):
         """ Send j keypress. """
         self._key(KEY_J)
-		
+
     def key_k(self):
         """ Send k keypress. """
         self._key(KEY_K)
-		
+
     def key_l(self):
         """ Send l keypress. """
         self._key(KEY_L)
-		
+
     def key_m(self):
         """ Send m keypress. """
         self._key(KEY_M)
-		
+
     def key_n(self):
         """ Send n keypress. """
         self._key(KEY_N)
-		
+
     def key_o(self):
         """ Send o keypress. """
         self._key(KEY_O)
-		
+
     def key_p(self):
         """ Send p keypress. """
         self._key(KEY_P)
-		
+
     def key_q(self):
         """ Send q keypress. """
         self._key(KEY_Q)
-		
+
     def key_r(self):
         """ Send r keypress. """
         self._key(KEY_R)
-		
+
     def key_s(self):
         """ Send s keypress. """
         self._key(KEY_S)
-		
+
     def key_t(self):
         """ Send t keypress. """
         self._key(KEY_T)
-		
+
     def key_u(self):
         """ Send u keypress. """
         self._key(KEY_U)
-		
+
     def key_v(self):
         """ Send v keypress. """
         self._key(KEY_V)
-		
+
     def key_w(self):
         """ Send w keypress. """
         self._key(KEY_W)
-		
+
     def key_x(self):
         """ Send x keypress. """
         self._key(KEY_X)
-		
+
     def key_y(self):
         """ Send y keypress. """
         self._key(KEY_Y)
-	
+
     def key_z(self):
         """ Send z keypress. """
         self._key(KEY_Z)

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ from setuptools import setup
 
 setup(
     name='firetv',
-    version='1.0.5.dev',
+    version='1.0.5.1',
     description='Communicate with an Amazon Fire TV device via ADB over a network.',
     url='https://github.com/happyleavesaoc/python-firetv/',
     license='MIT',
     author='happyleaves',
     author_email='happyleaves.tfr@gmail.com',
     packages=['firetv'],
-    install_requires=['adb==1.3.0.dev'],
+    install_requires=['pycryptodome', 'rsa', 'adb>=1.3.0'],
     extras_require={
         'firetv-server': ['Flask>=0.10.1', 'PyYAML>=3.12']
     },

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='firetv',
-    version='1.0.5.1',
+    version='1.0.5.2',
     description='Communicate with an Amazon Fire TV device via ADB over a network.',
     url='https://github.com/happyleavesaoc/python-firetv/',
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ from setuptools import setup
 
 setup(
     name='firetv',
-    version='1.0.5.3',
+    version='1.0.6',
     description='Communicate with an Amazon Fire TV device via ADB over a network.',
     url='https://github.com/happyleavesaoc/python-firetv/',
     license='MIT',
     author='happyleaves',
     author_email='happyleaves.tfr@gmail.com',
     packages=['firetv'],
-    install_requires=['pycryptodome', 'rsa', 'adb>=1.3.0'],
+    install_requires=['pycryptodome', 'rsa', 'adb>1.3.0'],
     extras_require={
         'firetv-server': ['Flask>=0.10.1', 'PyYAML>=3.12']
     },
@@ -22,5 +22,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='firetv',
-    version='1.0.5.2',
+    version='1.0.5.3',
     description='Communicate with an Amazon Fire TV device via ADB over a network.',
     url='https://github.com/happyleavesaoc/python-firetv/',
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author='happyleaves',
     author_email='happyleaves.tfr@gmail.com',
     packages=['firetv'],
-    install_requires=['pycryptodome', 'rsa', 'adb>1.3.0'],
+    install_requires=['pycryptodome', 'rsa', 'adb-homeassistant'],
     extras_require={
         'firetv-server': ['Flask>=0.10.1', 'PyYAML>=3.12']
     },


### PR DESCRIPTION
Now that ADB authentication is implemented, `pycryptodome` and `rsa` are required.  I've submitted a pull request for `adb` that will bump the version up to 1.3.0.1, but for now I'll put the requirement as 1.3.0 (although this version may lead to some errors when using an ADB key).  

Along with the previous pull request (https://github.com/happyleavesaoc/python-firetv/pull/61), this should close https://github.com/happyleavesaoc/python-firetv/issues/49, https://github.com/happyleavesaoc/python-firetv/issues/57, and https://github.com/happyleavesaoc/python-firetv/issues/60.  