### PR TITLE
Update href to ADB docs at Amazon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # python-firetv
 
-`firetv` is a Python 2 and 3 package that provides state information and some control of an Amazon Fire TV device over a network. This is achieved via ADB, so therefore requires [ADB Debugging](https://developer.amazon.com/public/solutions/devices/fire-tv/docs/connecting-adb-over-network) to be turned on. It includes `firetv-server`, an HTTP server to facilitate RESTful access to configured devices.
+`firetv` is a Python 2 and 3 package that provides state information and some control of an Amazon Fire TV device over a network. This is achieved via ADB, so therefore requires [ADB Debugging](https://developer.amazon.com/docs/fire-tv/connecting-adb-to-device.html) to be turned on. It includes `firetv-server`, an HTTP server to facilitate RESTful access to configured devices.
 
 ## Installation
 


### PR DESCRIPTION
Old href seems to be broken (404), the new one links to the "Connecting to Fire TV Through adb" section in the docs