### PR TITLE
Add support for using 'pure-python-adb' to send ADB commands

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author='happyleaves',
     author_email='happyleaves.tfr@gmail.com',
     packages=['firetv'],
-    install_requires=['pycryptodome', 'rsa', 'adb-homeassistant'],
+    install_requires=['pycryptodome', 'rsa', 'adb-homeassistant', 'pure-python-adb-homeassistant'],
     extras_require={
         'firetv-server': ['Flask>=0.10.1', 'PyYAML>=3.12']
     },


### PR DESCRIPTION
The Python package `adb` doesn't work so well for communicating with newer devices.  This pull request allows for using the [pure-python-adb](https://github.com/Swind/pure-python-adb) library to send commands.  Since this library works by communicating with a running ADB server instance, it is more robust than the `adb` package.  

Either Python package can be used, and there are no breaking changes.  This is accomplished by replacing the `self._adb.Shell` and `self._adb.StreamingShell` commands with `self._adb_shell` and `self._adb_streaming_shell` (see below), where these methods are defined accordingly for whichever of the two packages will be used for sending the ADB commands.  The `self.connect()` method is also modified accordingly.  

(from the `__init__` method)
```python
        # the method used for sending ADB commands
        if not self.adb_server_ip:
            # python-adb
            self._adb_shell = self._adb_shell_python_adb
            self._adb_streaming_shell = self._adb_streaming_shell_python_adb
        else:
            # pure-python-adb
            self._adb_shell = self._adb_shell_pure_python_adb
            self._adb_streaming_shell = self._adb_streaming_shell_pure_python_adb
```

(from the "ADB methods" section)
```python
    def _adb_shell_python_adb(self, cmd):
        if not self.available:
            return None
        return self._adb.Shell(cmd)


    def _adb_shell_pure_python_adb(self, cmd):
        if not self._available:
            return None
        return self._adb_device.shell(cmd)


    def _adb_streaming_shell_python_adb(self, cmd):
        if not self.available:
            return []
        return self._adb.StreamingShell(cmd)


    def _adb_streaming_shell_pure_python_adb(self, cmd):
        if not self._available:
            return None
        # this is not yet implemented
        return []
```