### PR TITLE
Make adb methods public; minimize ADB commands 

### DIFF
--- a/firetv/__init__.py
+++ b/firetv/__init__.py
@@ -119,12 +119,12 @@ class FireTV:
         # the methods used for sending ADB commands
         if not self.adb_server_ip:
             # python-adb
-            self._adb_shell = self._adb_shell_python_adb
-            self._adb_streaming_shell = self._adb_streaming_shell_python_adb
+            self.adb_shell = self._adb_shell_python_adb
+            self.adb_streaming_shell = self._adb_streaming_shell_python_adb
         else:
             # pure-python-adb
-            self._adb_shell = self._adb_shell_pure_python_adb
-            self._adb_streaming_shell = self._adb_streaming_shell_pure_python_adb
+            self.adb_shell = self._adb_shell_pure_python_adb
+            self.adb_streaming_shell = self._adb_streaming_shell_pure_python_adb
 
         # establish the ADB connection
         self.connect()
@@ -163,8 +163,8 @@ class FireTV:
         :returns: Dump, optionally grepped.
         """
         if grep:
-            return self._adb_shell('dumpsys {0} | grep "{1}"'.format(service, grep))
-        return self._adb_shell('dumpsys {0}'.format(service))
+            return self.adb_shell('dumpsys {0} | grep "{1}"'.format(service, grep))
+        return self.adb_shell('dumpsys {0}'.format(service))
 
     def _dump_has(self, service, grep, search):
         """Check if a dump has particular content.
@@ -186,7 +186,7 @@ class FireTV:
 
         :param key: Key constant.
         """
-        self._adb_shell('input keyevent {0}'.format(key))
+        self.adb_shell('input keyevent {0}'.format(key))
 
     def _ps(self, search=''):
         """Perform a ps command with optional filtering.
@@ -197,7 +197,7 @@ class FireTV:
         if not self.available:
             return
         result = []
-        ps = self._adb_streaming_shell('ps')
+        ps = self.adb_streaming_shell('ps')
         try:
             for bad_line in ps:
                 # The splitting of the StreamingShell doesn't always work
@@ -218,7 +218,7 @@ class FireTV:
 
         # adb shell outputs in weird format, so we cut it into lines,
         # separate the retcode and return info to the user
-        res = self._adb_shell(cmd)
+        res = self.adb_shell(cmd)
         if res is None:
             return {}
 


### PR DESCRIPTION
* Make the `_adb_shell` and `_adb_streaming_shell` commands public
* Add a method for getting 4 properties with 1 ADB command (screen_on, awake, wake_lock, and current_app)
* The turn_on method uses 1 command to check if the device is off and, if so, send the power and home keys
* The turn_off method uses 1 command to check if the device is on and, if so, sends the sleep key