### PR TITLE
Bump version to 1.0.9

### DIFF
--- a/firetv/__init__.py
+++ b/firetv/__init__.py
@@ -409,8 +409,8 @@ class FireTV:
         return self._send_intent(app, INTENT_LAUNCH)
 
     def stop_app(self, app):
-        """Stop an app (really, it just returns to the home screen)."""
-        return self._send_intent(PACKAGE_LAUNCHER, INTENT_HOME)
+        """Stop an app."""
+        return self.adb_shell("am force-stop {0}".format(app))
 
     # ======================================================================= #
     #                                                                         #

--- a/firetv/__init__.py
+++ b/firetv/__init__.py
@@ -593,7 +593,6 @@ class FireTV:
             current_app = {"package": pkg, "activity": activity}
         else:
             # case 2: current app could not be found
-            logging.warning("Couldn't get current app, reply was %s", lines[1])
             current_app = None
 
         # `running_apps` property

--- a/firetv/__init__.py
+++ b/firetv/__init__.py
@@ -112,6 +112,14 @@ KEYS = {'POWER': POWER,
         'LEFT': LEFT,
         'RIGHT': RIGHT}
 
+# Apps.
+AMAZON_VIDEO = 'com.amazon.avod'
+KODI = 'org.xbmc.kodi'
+NETFLIX = 'com.netflix.ninja'
+APPS = {AMAZON_VIDEO: 'Amazon Video',
+        KODI: 'Kodi',
+        NETFLIX: 'Netflix'}
+
 # Fire TV states.
 STATE_ON = 'on'
 STATE_IDLE = 'idle'

--- a/firetv/__init__.py
+++ b/firetv/__init__.py
@@ -45,6 +45,7 @@ SUCCESS1_FAILURE0 = r" && echo -e '1\c' || echo -e '0\c' "
 
 # ADB key event codes.
 HOME = 3
+CENTER = 23
 VOLUME_UP = 24
 VOLUME_DOWN = 25
 POWER = 26
@@ -103,7 +104,7 @@ KEY_Z = 54
 KEYS = {'POWER': POWER,
         'SLEEP': SLEEP,
         'HOME': HOME,
-        'ENTER': ENTER,
+        'CENTER': CENTER,
         'BACK': BACK,
         'MENU': MENU,
         'UP': UP,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='firetv',
-    version='1.0.8',
+    version='1.0.9',
     description='Communicate with an Amazon Fire TV device via ADB over a network.',
     url='https://github.com/happyleavesaoc/python-firetv/',
     license='MIT',


### PR DESCRIPTION
* Add 'CENTER' key and replace 'ENTER' in 'KEYS' dictionary
* Fix 'stop_app' method
* Add some apps
* Don't log failure to get current app in 'get_properties'
* Bump version to 1.0.9