### PR TITLE
Add 'always_log_errors' parameter to 'connect()' method

### DIFF
--- a/firetv/__init__.py
+++ b/firetv/__init__.py
@@ -294,7 +294,7 @@ class FireTV:
 
         return {"retcode": retcode, "output": output}
 
-    def connect(self):
+    def connect(self, always_log_errors=True):
         """Connect to an Amazon Fire TV device.
 
         Will attempt to establish ADB connection to the given host.
@@ -319,12 +319,14 @@ class FireTV:
                     self._available = True
 
                 except socket_error as serr:
-                    self._adb = None
-                    if self._available:
-                        self._available = False
+                    if self._available or always_log_errors:
                         if serr.strerror is None:
                             serr.strerror = "Timed out trying to connect to ADB device."
                         logging.warning("Couldn't connect to host: %s, error: %s", self.host, serr.strerror)
+
+                    # ADB connection attempt failed
+                    self._adb = None
+                    self._available = False
 
                 finally:
                     return self._available


### PR DESCRIPTION
## Scenario 1

If a user is running this code in a script or in the interactive Python interpreter, they probably want to see log messages about why the connection attempt failed. Accordingly, the default for `always_log_errors` is `True`. 

## Scenario 2

If a user is running this code in Home Assistant, a possible scenario is:

1. HA successfully connects to the Fire TV and sets up the component. 
2. The ADB connection gets broken for some reason; perhaps the Fire TV device restarts or drops offline. 
3. HA will attempt to reconnect on every subsequent update until it is successful. 

In this case, the user does not want to see the connection failed log message each time. By using `self.firetv.connect(always_log_messages=False)` in the HA component's `update` function, this logging message will only appear the first time that HA tries to reconnect, since `self.firetv._available` is `True`. After the first failed connection attempt, `self.firetv._available` will be set to `False` and these messages will not be logged. 