### PR TITLE
Use default adb key

### DIFF
--- a/firetv/__main__.py
+++ b/firetv/__main__.py
@@ -19,7 +19,10 @@ Find device IP:
 """
 
 import argparse
+import os
 import re
+from os.path import expanduser
+
 import yaml
 import logging
 from flask import Flask, jsonify, request, abort
@@ -258,8 +261,15 @@ def main():
     if args.config:
         _add_devices_from_config(args)
 
-    if args.default and not add('default', args.default):
+    home = expanduser("~")
+    adb_key = os.path.join(home, ".android", "adbkey")
+
+    if not os.path.exists(adb_key):
+        adb_key = ''
+
+    if args.default and not add('default', args.default, adbkey=adb_key):
         exit('invalid hostname')
+
     app.run(host='0.0.0.0', port=args.port)
 
 


### PR DESCRIPTION
I tried to run the python-firetv server and I had two problems:
- The AdbDevice of the adb_shell package is outdated and doesn't work 
- I got a lot of DeviceAuthErrors

To fix the device auth erros we have to add the adb key (at least of you use -d for the default ip). The default adbkey is for Linux and Mac in $HOME/.android and for Windows in %userprofile%\.android

So I updated the startup script to search for the default adbkey if you start the script with "-d" and to print an exception if the device connection fails. This could also help issue #84